### PR TITLE
Added theme refresh for Windows 11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ anyhow = "1"
 
 [dependencies.windows]
 version = "0.39"
-features = ["Win32_System_Registry", "Win32_Foundation", "Win32_Security", "Win32_UI_WindowsAndMessaging"]
+features = ["Win32_System_Registry", "Win32_Foundation", "Win32_Security", "Win32_UI_WindowsAndMessaging", "Win32_System_Threading", "Win32_System_ProcessStatus"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ anyhow = "1"
 
 [dependencies.windows]
 version = "0.39"
-features = ["Win32_System_Registry", "Win32_Foundation", "Win32_Security"]
+features = ["Win32_System_Registry", "Win32_Foundation", "Win32_Security", "Win32_UI_WindowsAndMessaging"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use notification::notify;
 mod notification;
 mod regkey;
 mod theme;
+mod refresh;
 
 use {
     chrono::{Datelike, Duration},

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -1,0 +1,89 @@
+use std::{
+    os::windows::prelude::OsStrExt,
+    ffi::OsStr,
+    thread::sleep,
+    time::Duration,
+    ptr::null_mut,
+    iter::once
+};
+
+use windows::Win32::{
+    Foundation::{
+        HWND,
+        LPARAM,
+        WPARAM,
+        BOOL
+    },
+    UI::WindowsAndMessaging::{
+        WM_THEMECHANGED,
+        EnumWindows,
+        WM_SETTINGCHANGE,
+        SendMessageTimeoutW,
+        SMTO_NORMAL
+    }
+};
+
+use crate::regkey::{
+    RegistryKey,
+    RegistryPermission
+};
+
+fn os_str(value: &str) -> Vec<u16> {
+    OsStr::new(value).encode_wide().chain(once(0)).collect()
+}
+
+unsafe extern "system" fn refresh_window_callback(hwnd: HWND, _: LPARAM) -> BOOL {
+    SendMessageTimeoutW(
+        hwnd,
+        WM_SETTINGCHANGE,
+        WPARAM(0),
+        LPARAM(os_str("ImmersiveColorSet").as_ptr() as isize),
+        SMTO_NORMAL,
+        400,
+        null_mut()
+    );
+
+    SendMessageTimeoutW(
+        hwnd,
+        WM_THEMECHANGED,
+        WPARAM(0),
+        LPARAM(0),
+        SMTO_NORMAL,
+        400,
+        null_mut()
+    );
+    
+    BOOL(1)
+}
+
+pub fn refresh_windows() {
+    sleep(Duration::from_millis(20));
+
+    let key = RegistryKey::open_or_create(
+        &RegistryKey::HKCU,
+        "SOFTWARE\\Microsoft\\Windows\\DWM",
+        RegistryPermission::ReadWrite,
+    );
+
+    // update accent color as a way to trigger apps that might listen to it
+    let accent = key.get_dword("AccentColor");
+    key.set_dword("AccentColor", accent + 1);
+    sleep(Duration::from_millis(10));
+    key.set_dword("AccentColor", accent);
+
+    // refresh the windows
+    unsafe {
+        EnumWindows(Some(refresh_window_callback), LPARAM(0));
+    }
+
+    // quite ugly hack:
+    // we refresh a few other times to ensure the windows get the call!
+    // e.g. the taskbar in windows 11 might not change its colors correctly!
+    for _ in 0..2 {
+        sleep(Duration::from_millis(3000));
+
+        unsafe {
+            EnumWindows(Some(refresh_window_callback), LPARAM(0));
+        }
+    }
+}

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -19,7 +19,7 @@ use windows::Win32::{
         EnumWindows,
         WM_SETTINGCHANGE,
         SendMessageTimeoutW,
-        SMTO_BLOCK,
+        SMTO_NORMAL,
         SMTO_NOTIMEOUTIFNOTHUNG
     }
 };
@@ -39,7 +39,7 @@ unsafe extern "system" fn refresh_window_callback(hwnd: HWND, _: LPARAM) -> BOOL
         WM_SETTINGCHANGE,
         WPARAM(0),
         LPARAM(os_str("ImmersiveColorSet").as_ptr() as isize),
-        SMTO_BLOCK | SMTO_NOTIMEOUTIFNOTHUNG,
+        SMTO_NORMAL | SMTO_NOTIMEOUTIFNOTHUNG,
         200,
         null_mut()
     );
@@ -49,7 +49,7 @@ unsafe extern "system" fn refresh_window_callback(hwnd: HWND, _: LPARAM) -> BOOL
         WM_THEMECHANGED,
         WPARAM(0),
         LPARAM(0),
-        SMTO_BLOCK | SMTO_NOTIMEOUTIFNOTHUNG,
+        SMTO_NORMAL | SMTO_NOTIMEOUTIFNOTHUNG,
         200,
         null_mut()
     );
@@ -58,8 +58,6 @@ unsafe extern "system" fn refresh_window_callback(hwnd: HWND, _: LPARAM) -> BOOL
 }
 
 pub fn refresh_windows() {
-    sleep(Duration::from_millis(20));
-
     let key = RegistryKey::open_or_create(
         &RegistryKey::HKCU,
         "SOFTWARE\\Microsoft\\Windows\\DWM",

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -12,7 +12,7 @@ use windows::Win32::{
         HWND,
         LPARAM,
         WPARAM,
-        BOOL
+        BOOL, HANDLE, HINSTANCE, CloseHandle
     },
     UI::WindowsAndMessaging::{
         WM_THEMECHANGED,
@@ -20,8 +20,8 @@ use windows::Win32::{
         WM_SETTINGCHANGE,
         SendMessageTimeoutW,
         SMTO_NORMAL,
-        SMTO_NOTIMEOUTIFNOTHUNG
-    }
+        SMTO_NOTIMEOUTIFNOTHUNG, GetWindowThreadProcessId
+    }, System::{Threading::{OpenProcess, PROCESS_QUERY_INFORMATION, PROCESS_VM_READ, QueryFullProcessImageNameW, PROCESS_NAME_FORMAT}, ProcessStatus::{K32GetModuleFileNameExW, K32GetModuleBaseNameW, K32GetProcessImageFileNameW}}
 };
 
 use crate::regkey::{
@@ -33,26 +33,72 @@ fn os_str(value: &str) -> Vec<u16> {
     OsStr::new(value).encode_wide().chain(once(0)).collect()
 }
 
-unsafe extern "system" fn refresh_window_callback(hwnd: HWND, _: LPARAM) -> BOOL {
-    SendMessageTimeoutW(
-        hwnd,
-        WM_SETTINGCHANGE,
-        WPARAM(0),
-        LPARAM(os_str("ImmersiveColorSet").as_ptr() as isize),
-        SMTO_NORMAL | SMTO_NOTIMEOUTIFNOTHUNG,
-        200,
-        null_mut()
-    );
+pub fn get_process_name(hwnd: HWND) -> Option<String> {
+    unsafe {
+        let mut process_id = 0;
 
-    SendMessageTimeoutW(
-        hwnd,
-        WM_THEMECHANGED,
-        WPARAM(0),
-        LPARAM(0),
-        SMTO_NORMAL | SMTO_NOTIMEOUTIFNOTHUNG,
-        200,
-        null_mut()
-    );
+        if GetWindowThreadProcessId(hwnd, &mut process_id as *mut u32) == 0 {
+            return None;
+        }
+        
+        let Ok(process) = OpenProcess(
+            PROCESS_QUERY_INFORMATION | PROCESS_VM_READ,
+            false,
+            process_id
+        ) else {
+            return None;
+        };
+
+        let mut process_name = [0u16; 512];
+        let mut length = process_name.len() as u32 - 1;
+
+        let has_image_name = QueryFullProcessImageNameW(
+            process,
+            PROCESS_NAME_FORMAT(0),
+            windows::core::PWSTR(&mut process_name as *mut u16),
+            &mut length
+        ).as_bool();
+        CloseHandle(process);
+
+        if has_image_name {
+            String::from_utf16(&process_name).ok()
+        } else {
+            None
+        }
+    }
+}
+
+unsafe extern "system" fn refresh_window_callback(hwnd: HWND, _: LPARAM) -> BOOL {
+    // these processes are known to require refreshes
+    let whitelist = vec![
+        "explorer.exe"
+    ];
+
+    let Some(process_name) = get_process_name(hwnd) else {
+        return BOOL(1);
+    };
+
+    if whitelist.iter().any(|&w| process_name.contains(w)) {
+        SendMessageTimeoutW(
+            hwnd,
+            WM_SETTINGCHANGE,
+            WPARAM(0),
+            LPARAM(os_str("ImmersiveColorSet").as_ptr() as isize),
+            SMTO_NORMAL | SMTO_NOTIMEOUTIFNOTHUNG,
+            200,
+            null_mut()
+        );
+    
+        SendMessageTimeoutW(
+            hwnd,
+            WM_THEMECHANGED,
+            WPARAM(0),
+            LPARAM(0),
+            SMTO_NORMAL | SMTO_NOTIMEOUTIFNOTHUNG,
+            200,
+            null_mut()
+        );
+    }
     
     BOOL(1)
 }

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -19,7 +19,8 @@ use windows::Win32::{
         EnumWindows,
         WM_SETTINGCHANGE,
         SendMessageTimeoutW,
-        SMTO_NORMAL
+        SMTO_BLOCK,
+        SMTO_NOTIMEOUTIFNOTHUNG
     }
 };
 
@@ -38,8 +39,8 @@ unsafe extern "system" fn refresh_window_callback(hwnd: HWND, _: LPARAM) -> BOOL
         WM_SETTINGCHANGE,
         WPARAM(0),
         LPARAM(os_str("ImmersiveColorSet").as_ptr() as isize),
-        SMTO_NORMAL,
-        400,
+        SMTO_BLOCK | SMTO_NOTIMEOUTIFNOTHUNG,
+        200,
         null_mut()
     );
 
@@ -48,8 +49,8 @@ unsafe extern "system" fn refresh_window_callback(hwnd: HWND, _: LPARAM) -> BOOL
         WM_THEMECHANGED,
         WPARAM(0),
         LPARAM(0),
-        SMTO_NORMAL,
-        400,
+        SMTO_BLOCK | SMTO_NOTIMEOUTIFNOTHUNG,
+        200,
         null_mut()
     );
     
@@ -73,17 +74,6 @@ pub fn refresh_windows() {
 
     // refresh the windows
     unsafe {
-        EnumWindows(Some(refresh_window_callback), LPARAM(0));
-    }
-
-    // quite ugly hack:
-    // we refresh a few other times to ensure the windows get the call!
-    // e.g. the taskbar in windows 11 might not change its colors correctly!
-    for _ in 0..2 {
-        sleep(Duration::from_millis(3000));
-
-        unsafe {
-            EnumWindows(Some(refresh_window_callback), LPARAM(0));
-        }
+        EnumWindows(Some(refresh_window_callback), LPARAM(1));
     }
 }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,4 +1,4 @@
-use crate::regkey::RegistryKey;
+use crate::{regkey::{RegistryKey, RegistryPermission}, refresh::refresh_windows};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ThemeVariant {
@@ -24,8 +24,11 @@ pub fn set_theme(variant: ThemeVariant) {
     let key = RegistryKey::open_or_create(
         &RegistryKey::HKCU,
         "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
+        RegistryPermission::Write,
     );
 
     key.set_dword("AppsUseLightTheme", value);
     key.set_dword("SystemUsesLightTheme", value);
+
+    refresh_windows();
 }


### PR DESCRIPTION
Fixes a bug on Windows 11 that makes autolight unable to refresh the explorer and the taskbar.

This pull requests aims to fix this specific issue.